### PR TITLE
SETI-295: Reduce index bloat

### DIFF
--- a/spec/debloater/engine_spec.rb
+++ b/spec/debloater/engine_spec.rb
@@ -12,6 +12,7 @@ describe Debloater::Engine do
     conn.exec %{
       DROP TABLE IF EXISTS bloated1;
       DROP TABLE IF EXISTS bloated2;
+      DROP TABLE IF EXISTS bloated3;
     }
 
     conn.exec %{
@@ -22,20 +23,41 @@ describe Debloater::Engine do
 
       CREATE TABLE bloated2 (id bigint primary key, stuff varchar);
       CREATE INDEX idx_fts ON bloated2 USING gin (to_tsvector('english', stuff));
+
+      CREATE TABLE bloated3 (id bigint primary key, stuff bigint);
+      CREATE UNIQUE INDEX idx_bloated3 ON bloated3 (stuff);
     }
 
-    (1..1_000).to_a.shuffle.each do |idx|
+
+    %w[bloated1 bloated2].each do |table|
+      (1..1_000).to_a.shuffle.each do |id|
+        conn.exec_params(%{
+          INSERT INTO #{table} VALUES ($1, $2);
+        }, [id, SecureRandom.hex(rand(64) + 63)])
+      end
+    end
+
+    (1..1_000).to_a.shuffle.each_with_index do |id,idx|
       conn.exec_params(%{
-        INSERT INTO bloated1 VALUES ($1, $2);
-      }, [idx, SecureRandom.hex(rand(64) + 63)])
-      conn.exec_params(%{
-        INSERT INTO bloated2 VALUES ($1, $2);
-      }, [idx, SecureRandom.hex(rand(64) + 63)])
+        INSERT INTO bloated3 VALUES ($1, $2);
+      }, [id, idx])
     end
   end
 
-  it 'debloats the valid index' do
+  it 'debloats the valid indices' do
     result = subject.run
-    expect(result.first.name).to eq('idx_bloated1')
+    expect(result.map(&:name)).to eq(%w[idx_bloated1 idx_bloated3])
+  end
+
+  it 'creates indices concurrently' do
+    allow(conn).to receive(:exec).and_wrap_original do |m, *args|
+      sql = args.first
+      if sql =~ /CREATE/
+        expect(sql).to match(/CONCURRENTLY/)
+      end
+      m.call(*args)
+    end
+
+    subject.run
   end
 end


### PR DESCRIPTION
Bug fix: `UNIQUE` indexes were not re-created `CONCURRENTLY` (bad!)

Feature: deadlocks in the final "swap the indices" transaction are detected and can be retried.

===

Jira story [#SETI-295](https://deliveroo.atlassian.net/browse/SETI-295) in project *Software Engineering Tools and Infrastructure*.